### PR TITLE
Use go.uber.org/multierr

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -43,6 +43,7 @@ import (
 	"reflect"
 
 	"github.com/mitchellh/mapstructure"
+	"go.uber.org/multierr"
 )
 
 const _tagName = "mapdecode"
@@ -171,7 +172,14 @@ func decodeFrom(src interface{}) Into {
 			return fmt.Errorf("failed to set up decoder: %v", err)
 		}
 
-		return decoder.Decode(src)
+		if err := decoder.Decode(src); err != nil {
+			if merr, ok := err.(*mapstructure.Error); ok {
+				return multierr.Combine(merr.WrappedErrors()...)
+			}
+			return err
+		}
+
+		return nil
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 608ff2b117f39a38f2c5ead39068d40f24deafd680fffdc52a3fc5679cd71a1a
-updated: 2017-03-31T14:27:08.777590432-07:00
+hash: 8bb7bb901121c893a93e5ecbe9b6ea7841e9fe43f5fa8d2717cc8e8552fe5a71
+updated: 2017-03-31T14:52:16.886801606-07:00
 imports:
 - name: github.com/mitchellh/mapstructure
   version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+- name: go.uber.org/multierr
+  version: de6740a55f8d778e53755317dc50aae950c760de
 testImports:
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/uber-go/mapdecode
 import:
 - package: github.com/mitchellh/mapstructure
+- package: go.uber.org/multierr
 testImport:
 - package: github.com/stretchr/testify
   subpackages:


### PR DESCRIPTION
The errors returned by mapstructure are multi-line by default. `multierr`
errors are multi-line only if you use `%+v`.