### PR TITLE
multierr: Lock to minor release 0.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 8bb7bb901121c893a93e5ecbe9b6ea7841e9fe43f5fa8d2717cc8e8552fe5a71
-updated: 2017-03-31T14:52:16.886801606-07:00
+hash: c14f9c2d857a16d60b5ae6f3bd0dab87253be060a4179f3e125681a9ad1bb45e
+updated: 2017-03-31T17:22:29.230311237-07:00
 imports:
 - name: github.com/mitchellh/mapstructure
   version: 53818660ed4955e899c0bcafa97299a388bd7c8e
 - name: go.uber.org/multierr
-  version: de6740a55f8d778e53755317dc50aae950c760de
+  version: 737b41aa3bf31c25d11dc84d5275af6bfe2ef4d2
 testImports:
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
@@ -18,3 +18,4 @@ testImports:
   version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,7 @@ package: github.com/uber-go/mapdecode
 import:
 - package: github.com/mitchellh/mapstructure
 - package: go.uber.org/multierr
+  version: ~0.1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:


### PR DESCRIPTION
Let's consume multierr safely until it hits 1.0.